### PR TITLE
skip all versions that are not lax

### DIFF
--- a/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
+++ b/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
@@ -69,7 +69,7 @@ sub before_release {
       $requirement{ $pkg } //= version->parse(0);
 
       # we have a complex, stupid rule -- rjbs, 2011-08-18
-      next REQ_PKG if $ver =~ /<>=,\s/;
+      next REQ_PKG if not version::is_lax($ver);
 
       $requirement{ $pkg } = $ver
         if version->parse($ver) > $requirement{ $pkg };


### PR DESCRIPTION
I got this:
Invalid version format (non-numeric data) at /Users/ether/.perlbrew/libs/19.9@std/lib/perl5/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm line 54.

...when I had a prereq specification like this: ">= 0.04, != 0.06"

Now, you did have this regexp: `/<>=,\s/`, but I think you meant `/[<>=,\s]/` ;)  But just checking for whether `version->parse` will blow up is a little more safe.

(Of course, the _real_ fix should be to use CPAN::Meta::Check to parse the version spec against what's installed, but that's a larger change and would benefit by a bit more code reorg. Another day, I think!)
