### PR TITLE
skip checking prereqs that will be satisfied by the current release

### DIFF
--- a/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
+++ b/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
@@ -63,15 +63,17 @@ sub before_release {
 
   # first level keys are phase; second level keys are types; we will just merge
   # everything -- rjbs, 2011-08-18
-  for my $req_set (map { values %$_ } values %$prereqs_hash) {
-    REQ_PKG: for my $pkg (keys %$req_set) {
-      next if $NOT_INDEXED{ $pkg };
+  for my $phase (keys %$prereqs_hash) {
+    for my $type (keys %{$prereqs_hash->{$phase}}) {
+      REQ_PKG: for my $pkg (keys %{$prereqs_hash->{$phase}{$type}}) {
+        next if $NOT_INDEXED{ $pkg };
 
-      next if any { $pkg =~ $_ } @skips;
+        next if any { $pkg =~ $_ } @skips;
 
-      my $ver = $req_set->{$pkg};
+        my $ver = $prereqs_hash->{$phase}{$type}{$pkg};
 
-      $requirements->add_string_requirement($pkg => $ver);
+        $requirements->add_string_requirement($pkg => $ver);
+      }
     }
   }
 

--- a/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
+++ b/lib/Dist/Zilla/Plugin/CheckPrereqsIndexed.pm
@@ -66,9 +66,15 @@ sub before_release {
   for my $phase (keys %$prereqs_hash) {
     for my $type (keys %{$prereqs_hash->{$phase}}) {
       REQ_PKG: for my $pkg (keys %{$prereqs_hash->{$phase}{$type}}) {
-        next if $NOT_INDEXED{ $pkg };
+        if ($NOT_INDEXED{ $pkg }) {
+          $self->log_debug([ 'skipping unindexed module %s', $pkg ]);
+          next;
+        }
 
-        next if any { $pkg =~ $_ } @skips;
+        if (any { $pkg =~ $_ } @skips) {
+          $self->log_debug([ 'explicitly skipping module %s', $pkg ]);
+          next;
+        }
 
         my $ver = $prereqs_hash->{$phase}{$type}{$pkg};
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -4,6 +4,8 @@ use Test::More 0.88;
 use Test::Fatal;
 use Test::DZil;
 
+use if !$ENV{AUTHOR_TESTING}, 'Test::RequiresInternet' => ('http://cpanmetadb.plackperl.org' => 80);
+
 sub new_tzil {
   my ($corpus_dir, @skips) = @_;
   my $tzil = Builder->from_config(

--- a/t/basic.t
+++ b/t/basic.t
@@ -2,9 +2,6 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use Test::Fatal;
-
-use lib 't/lib';
-
 use Test::DZil;
 
 sub new_tzil {

--- a/t/skip-self.t
+++ b/t/skip-self.t
@@ -1,0 +1,105 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use Test::DZil;
+use Test::Fatal;
+use Test::Deep;
+
+use if !$ENV{AUTHOR_TESTING}, 'Test::RequiresInternet' => ('http://cpanmetadb.plackperl.org' => 80);
+
+my $dist_version = '0.005';
+
+{
+  package SimpleProvides;
+  use Moose;
+  with 'Dist::Zilla::Role::MetaProvider';
+  sub metadata {
+    return +{
+      provides => {
+        'Foo::Bar' => {
+          file => 'lib/Foo/Bar.pm',
+          version => $dist_version,
+        },
+        'Foo::Bar::Baz' => {
+          file => 'lib/Foo/Bar/Baz.pm',
+          version => $dist_version,
+        },
+      },
+    };
+  }
+}
+
+foreach my $dep_pkg (qw(Foo::Bar Foo::Bar::Baz)) {
+
+  foreach my $prereqs (
+    [ runtime => $dist_version ],         # release not ok
+    [ develop => $dist_version + 0.001 ], # release not ok
+    [ develop => $dist_version ],         # release ok
+    [ develop => $dist_version - 0.001 ], # release ok
+  )
+  {
+    my ($phase, $dep_version) = @$prereqs;
+    note ''; note "$phase prereq: $dep_pkg => $dep_version";
+
+    my $tzil = Builder->from_config(
+      { dist_root => 'does-not-exist' },
+      {
+        add_files => {
+          'source/dist.ini' => simple_ini(
+            { # merge into root section
+              name => 'Foo-Bar',
+              version => $dist_version,
+            },
+            [ GatherDir => ],
+            [ Prereqs => { 'strict' => 0 } ],
+            [ Prereqs => ucfirst($phase) . 'Requires' => { $dep_pkg => $dep_version } ],
+            [ CheckPrereqsIndexed => ],
+            $dep_pkg eq 'Foo::Bar' ? () : [ '=SimpleProvides' ],
+            [ FakeRelease => ],
+          ),
+          'source/lib/Foo/Bar.pm' => "package Foo::Bar;\n1;\n",
+          'source/lib/Foo/Bar Baz.pm' => "package Foo::Bar::Baz;\n1;\n",
+        },
+      },
+    );
+
+    $tzil->chrome->logger->set_debug(1);
+
+    if ($phase eq 'develop' and $dep_version <= $dist_version) {
+      is(
+        exception { $tzil->release },
+        undef,
+        'build proceeds normally',
+      );
+
+      cmp_deeply(
+        $tzil->log_messages,
+        superbagof(
+          "[CheckPrereqsIndexed] skipping develop prereq on ourself ($dep_pkg => $dep_version)",
+        ),
+        'skipped self dependency',
+      );
+    }
+    else {
+      like(
+        exception { $tzil->release },
+        qr/aborting release due to apparently unindexed prereqs/,
+        'release was aborted',
+      );
+
+      cmp_deeply(
+        $tzil->log_messages,
+        superbagof(
+        "[CheckPrereqsIndexed] the following prereqs could not be found on CPAN: $dep_pkg",
+        ),
+        "found $phase dependency on self that will not be satisfied by the current release",
+      );
+    }
+
+    diag 'got log messages: ', explain $tzil->log_messages
+      if not Test::Builder->new->is_passing;
+  }
+}
+
+done_testing;


### PR DESCRIPTION
Only develop prereqs of this nature are allowed -- all others would be
circular dependencies -- but a distribution can have a develop prereq on
itself.
