### PR TITLE
add missing test prereq

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - fixed missing test prereq from 0.019 (Karen Etheridge)
 
 0.019     2016-09-14 23:09:47-04:00 America/New_York
         - also check prereqs from optional features (thanks, Karen Etheridge)

--- a/dist.ini
+++ b/dist.ini
@@ -6,5 +6,8 @@ copyright_year   = 2011
 
 [@RJBS]
 
+[Prereqs / TestRequires]
+Test::RequiresInternet = 0
+
 [MetaNoIndex]
 dir = corpus


### PR DESCRIPTION
Perl::PrereqScanner does not detect: use if <condition>, '$module';